### PR TITLE
Primitive functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,6 @@ A simple functional programming language inspired by MinCaml and Tiger.
 A functional programming language.
 Its syntax is based on Haskell.
 
-### Primitives
-
-```
-data Int32 = Int32# Int32#
-data Int64 = Int64# Int64#
-
-add_i32# :: (Int32#, Int32#) -> Int32#
-add_i64# :: (Int64#, Int64#) -> Int64#
-```
-
 # Future works
 
 * Rich build tool like go, cargo, cabal

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Its syntax is based on Haskell.
 * Rich build tool like go, cargo, cabal
 
 * Griff
+  + Import Builtin.grf implicity
   + Literals for Boxed types (Int32, Int64, Float, Double, Char, String)
   + Mutable (unboxed | boxed) polymorphic array (in Koriel, Array)
   + More rich standard library

--- a/examples/griff/FuncOverUnboxed.grf
+++ b/examples/griff/FuncOverUnboxed.grf
@@ -1,4 +1,4 @@
-module FuncOverUnboxed {
+module FuncOverUnboxed = {
   foreign import print_int :: Int64# -> ();
 
   f = { 0L# -> print_int 1L#

--- a/examples/griff/Infixing.grf
+++ b/examples/griff/Infixing.grf
@@ -1,7 +1,7 @@
 module Infixing = {
-    data Int = Int# Int64#;
+    import Builtin;
 
-    add = {(Int# x, Int# y) -> Int# (add_i64# (x, y))};
+    add = {(Int64# x, Int64# y) -> Int64# (add_Int64# x y)};
 
     infixl 3 (<\);
     (<\) = {x f -> {y -> f (x, y)}};
@@ -17,11 +17,11 @@ module Infixing = {
 
     foreign import print_int :: Int64# -> ();
 
-    printInt = {Int# x -> print_int x};
+    printInt = {Int64# x -> print_int x};
 
     main = {
-        printInt (Int# 1L# <\add\> Int# 2L#);
-        printInt (Int# 1L# </add/> Int# 2L#);
+        printInt (Int64# 1L# <\add\> Int64# 2L#);
+        printInt (Int64# 1L# </add/> Int64# 2L#);
     };
 }
 

--- a/examples/griff/List.grf
+++ b/examples/griff/List.grf
@@ -1,8 +1,8 @@
 module list = {
-  data Int = Int# Int64#;
-  
+  import Builtin; 
+
   infixl 6 (+#);
-  (+#) = {x y -> add_i64# (x, y)};
+  (+#) = {x y -> add_Int64# x y};
   
   infixl 0 (|>);
   (|>) :: a -> (a -> b) -> b;
@@ -17,16 +17,16 @@ module list = {
            | (Cons x xs) -> Cons (f x) (map f xs)
            };
   
-  sum = { Nil -> Int# 0L#
-        | (Cons (Int# x) xs) ->
-            sum xs |> {(Int# s) -> Int# (x +# s)}
+  sum = { Nil -> Int64# 0L#
+        | (Cons (Int64# x) xs) ->
+            sum xs |> {(Int64# s) -> Int64# (x +# s)}
         };
   
   foreign import print_int :: Int64# -> ();
   
   main = {
-      sum (Cons (Int# 1L#) (Cons (Int# 2L#) Nil))
-        |> {(Int# i) -> print_int i}
+      sum (Cons (Int64# 1L#) (Cons (Int64# 2L#) Nil))
+        |> {(Int64# i) -> print_int i}
       }
 }
 -- Expected: 3

--- a/examples/griff/Primitive.grf
+++ b/examples/griff/Primitive.grf
@@ -1,0 +1,7 @@
+module Primitive = {
+  import Builtin;
+  foreign import print_int :: Int64# -> ();
+  main = { print_int (add_Int64# 40L# 2L#) };
+}
+
+-- Expected: 42

--- a/examples/griff/Test0.grf
+++ b/examples/griff/Test0.grf
@@ -1,15 +1,15 @@
 module test0 = {
+  import Builtin;
+
   infixl 0 (|>);
   (|>) :: a -> (a -> b) -> b;
   (|>) x f = f x;
   
   foreign import print_int :: Int64# -> ();
   
-  data Int = Int# Int64#;
-  
   infixl 6 (+#);
-  (+#) = {x y -> add_i64# (x, y)};
+  (+#) = {x y -> add_Int64# x y};
   
-  main = { Int# 1L# |> {(Int# i) -> print_int i} };
+  main = { Int64# 1L# |> {(Int64# i) -> print_int i} };
 }
 -- Expected: 1

--- a/examples/griff/Test4.grf
+++ b/examples/griff/Test4.grf
@@ -1,11 +1,11 @@
 module test4 = {
-  data Int = Int# Int64#;
+  import Builtin;
 
   infixl 6 (+#);
-  (+#) = {x y -> add_i64# (x, y)};
+  (+#) = {x y -> add_Int64# x y};
 
   infixl 6 (+);
-  (+) = {(Int# x) (Int# y) -> Int# (x +# y) };
+  (+) = {(Int64# x) (Int64# y) -> Int64# (x +# y) };
 
   data List a = Nil | Cons a (List a);
 
@@ -15,8 +15,8 @@ module test4 = {
   foreign import print_int :: Int64# -> ();
 
   main = {
-    {(Int# i) -> print_int i}
-      (sum (Int# 0L#) (Cons (Int# 1L#) (Cons (Int# 2L#) Nil)))
+    {(Int64# i) -> print_int i}
+      (sum (Int64# 0L#) (Cons (Int64# 1L#) (Cons (Int64# 2L#) Nil)))
     }
 }
 -- Expected: 3

--- a/examples/griff/TestDot.grf
+++ b/examples/griff/TestDot.grf
@@ -1,11 +1,11 @@
 module testDot = {
-  data Int64 = Int64# Int64#;
-
+  import Builtin;
+  
   infixr 9 (.);
   (.) :: (b -> c) -> (a -> b) -> (a -> c);
   (.) = {f g -> {x -> f (g x)}};
 
-  succ = {(Int64# x) -> (Int64# (add_i64# (x, 1L#)))};
+  succ = {(Int64# x) -> (Int64# (add_Int64# x 1L#))};
 
   foreign import print_int64 :: Int64# -> ();
 

--- a/examples/griff/TestLet.grf
+++ b/examples/griff/TestLet.grf
@@ -1,17 +1,17 @@
 module testLet = {
-  foreign import print_int32 :: Int32# -> ();
+  import Builtin;
 
-  data Int32 = Int32# Int32#;
+  foreign import print_int32 :: Int32# -> ();
 
   infixl 0 (|>);
   (|>) :: a -> (a -> b) -> b;
   (|>) = {x f -> f x};
 
   main = {
-    let x = add_i32# (1#, 2#);
+    let x = add_Int32# 1# 2#;
     print_int32 x;
 
-    let x = Int32# (add_i32# (1#, 2#));
+    let x = Int32# (add_Int32# 1# 2#);
     let printInt32 = {(Int32# x) -> print_int32 x};
     printInt32 x;
   }

--- a/examples/griff/TestPatSynRecon.grf
+++ b/examples/griff/TestPatSynRecon.grf
@@ -1,8 +1,8 @@
 module testPatSynRecon = {
-  data Int = Int# Int64#;
-  
+  import Builtin;
+
   infixl 6 (+#);
-  (+#) = {x y -> add_i64# (x, y)};
+  (+#) = {x y -> add_Int64# x y};
   
   infixl 0 (|>);
   (|>) :: a -> (a -> b) -> b;
@@ -10,16 +10,16 @@ module testPatSynRecon = {
   
   data List a = Nil | Cons a (List a);
 
-  sum = { Cons (Int# x) xs ->
-            sum xs |> {(Int# s) -> Int# (x +# s)}
-        | Nil -> Int# 0L#
+  sum = { Cons (Int64# x) xs ->
+            sum xs |> {(Int64# s) -> Int64# (x +# s)}
+        | Nil -> Int64# 0L#
         };
   
   foreign import print_int :: Int64# -> ();
   
   main = {
-      sum (Cons (Int# 1L#) (Cons (Int# 2L#) Nil))
-        |> {(Int# i) -> print_int i}
+      sum (Cons (Int64# 1L#) (Cons (Int64# 2L#) Nil))
+        |> {(Int64# i) -> print_int i}
       }
 }
 -- Expected: 3

--- a/examples/griff/TestPrimitive.grf
+++ b/examples/griff/TestPrimitive.grf
@@ -1,10 +1,12 @@
 module testPrimitive = {
+  import Builtin;
+
   foreign import print_int32 :: Int32# -> ();
   foreign import print_int64 :: Int64# -> ();
 
   main = {
-    print_int32 (add_i32# (1#, 2#));
-    print_int64 (add_i64# (1L#, 2L#))
+    print_int32 (add_Int32# 1# 2#);
+    print_int64 (add_Int64# 1L# 2L#)
   }
 }
 -- Expected: 33

--- a/griff/src/Language/Griff/Rename/RnEnv.hs
+++ b/griff/src/Language/Griff/Rename/RnEnv.hs
@@ -48,10 +48,6 @@ makeLenses ''RnEnv
 
 genBuiltinRnEnv :: MonadUniq m => m RnEnv
 genBuiltinRnEnv = do
-  -- generate RnId of primitive functions and operetors
-  add_i32 <- newTopLevelId "add_i32#" $ ModuleName "Builtin"
-  add_i64 <- newTopLevelId "add_i64#" $ ModuleName "Builtin"
-
   -- generate RnTId of primitive types
   int32_t <- newTopLevelId "Int32#" $ ModuleName "Builtin"
   int64_t <- newTopLevelId "Int64#" $ ModuleName "Builtin"
@@ -61,7 +57,7 @@ genBuiltinRnEnv = do
   string_t <- newTopLevelId "String#" $ ModuleName "Builtin"
   pure $
     RnEnv
-      { _varEnv = Map.fromList [("add_i32#", add_i32), ("add_i64#", add_i64)],
+      { _varEnv = mempty,
         _typeEnv =
           Map.fromList
             [ ("Int32#", int32_t),

--- a/griff/src/Language/Griff/TypeCheck/TcEnv.hs
+++ b/griff/src/Language/Griff/TypeCheck/TcEnv.hs
@@ -65,32 +65,23 @@ overTypeDef f = traverseOf constructor f <=< traverseOf (union . traversed . _2)
 
 genTcEnv :: MonadUniq m => RnEnv -> m TcEnv
 genTcEnv rnEnv = do
-  -- lookup RnId of primitive functions and operetors
-  let add_i32 = fromJust $ Map.lookup "add_i32#" (view R.varEnv rnEnv)
-  let add_i64 = fromJust $ Map.lookup "add_i64#" (view R.varEnv rnEnv)
   -- lookup RnTId of primitive types
   let int32_t = fromJust $ Map.lookup "Int32#" (view R.typeEnv rnEnv)
   let int64_t = fromJust $ Map.lookup "Int64#" (view R.typeEnv rnEnv)
   let float_t = fromJust $ Map.lookup "Float#" (view R.typeEnv rnEnv)
   let double_t = fromJust $ Map.lookup "Double#" (view R.typeEnv rnEnv)
+  let char_t = fromJust $ Map.lookup "Char#" (view R.typeEnv rnEnv)
   let string_t = fromJust $ Map.lookup "String#" (view R.typeEnv rnEnv)
   pure $
     TcEnv
-      { _varEnv =
-          Map.fromList
-            [ ( add_i32,
-                Forall [] (TyTuple [TyPrim Int32T, TyPrim Int32T] `TyArr` TyPrim Int32T)
-              ),
-              ( add_i64,
-                Forall [] (TyTuple [TyPrim Int64T, TyPrim Int64T] `TyArr` TyPrim Int64T)
-              )
-            ],
+      { _varEnv = mempty,
         _typeEnv =
           Map.fromList
             [ (int32_t, TypeDef (TyPrim Int32T) [] []),
               (int64_t, TypeDef (TyPrim Int64T) [] []),
               (float_t, TypeDef (TyPrim FloatT) [] []),
               (double_t, TypeDef (TyPrim DoubleT) [] []),
+              (char_t, TypeDef (TyPrim CharT) [] []),
               (string_t, TypeDef (TyPrim StringT) [] [])
             ],
         _rnEnv = rnEnv

--- a/runtime/griff/Builtin.grf
+++ b/runtime/griff/Builtin.grf
@@ -1,0 +1,56 @@
+module Builtin = {
+  data Int32 = Int32# Int32#;
+  data Int64 = Int64# Int64#;
+  data Float = Float# Float#;
+  data Double = Double# Double#;
+  data Char = Char# Char#;
+  data String = String# String#;
+
+  foreign import add_i32 :: Int32# -> Int32# -> Int32#;
+  add_Int32# = { x y -> add_i32 x y };
+
+  foreign import add_i64 :: Int64# -> Int64# -> Int64#;
+  add_Int64# = { x y -> add_i64 x y };
+
+  foreign import add_float :: Float# -> Float# -> Float#;
+  add_Float# = { x y -> add_float x y };
+
+  foreign import add_double :: Double# -> Double# -> Double#;
+  add_Double# = { x y -> add_double x y };
+
+  foreign import sub_i32 :: Int32# -> Int32# -> Int32#;
+  sub_Int32# = { x y -> sub_i32 x y };
+
+  foreign import sub_i64 :: Int64# -> Int64# -> Int64#;
+  sub_Int64# = { x y -> sub_i64 x y };
+
+  foreign import sub_float :: Float# -> Float# -> Float#;
+  sub_Float# = { x y -> sub_float x y };
+
+  foreign import sub_double :: Double# -> Double# -> Double#;
+  sub_Double# = { x y -> sub_double x y };
+
+  foreign import mul_i32 :: Int32# -> Int32# -> Int32#;
+  mul_Int32# = { x y -> mul_i32 x y };
+
+  foreign import mul_i64 :: Int64# -> Int64# -> Int64#;
+  mul_Int64# = { x y -> mul_i64 x y };
+
+  foreign import mul_float :: Float# -> Float# -> Float#;
+  mul_Float# = { x y -> mul_float x y };
+
+  foreign import mul_double :: Double# -> Double# -> Double#;
+  mul_Double# = { x y -> mul_double x y };
+
+  foreign import div_i32 :: Int32# -> Int32# -> Int32#;
+  div_Int32# = { x y -> div_i32 x y };
+
+  foreign import div_i64 :: Int64# -> Int64# -> Int64#;
+  div_Int64# = { x y -> div_i64 x y };
+
+  foreign import div_float :: Float# -> Float# -> Float#;
+  div_Float# = { x y -> div_float x y };
+
+  foreign import div_double :: Double# -> Double# -> Double#;
+  div_Double# = { x y -> div_double x y };
+}

--- a/runtime/griff/Prelude.grf
+++ b/runtime/griff/Prelude.grf
@@ -1,4 +1,6 @@
 module Prelude = {
+  import Builtin;
+
   infixl 0 (|>);
   (|>) :: a -> (a -> b) -> b;
   (|>) = {x f -> f x};
@@ -20,8 +22,6 @@ module Prelude = {
 
   foreign import print_string :: String# -> ();
   foreign import newline :: () -> ();
-
-  data String = String# String#;
 
   putStr :: String -> ();
   putStr = { (String# str) -> print_string str };

--- a/runtime/griff/rts.c
+++ b/runtime/griff/rts.c
@@ -3,6 +3,70 @@
 #include <stdlib.h>
 #include <inttypes.h>
 
+int32_t add_i32(int32_t x, int32_t y) {
+  return x + y;
+}
+
+int64_t add_i64(int64_t x, int64_t y) {
+  return x + y;
+}
+
+float add_float(float x, float y) {
+  return x + y;
+}
+
+double add_double(double x, double y) {
+  return x + y;
+}
+
+int32_t sub_i32(int32_t x, int32_t y) {
+  return x - y;
+}
+
+int64_t sub_i64(int64_t x, int64_t y) {
+  return x - y;
+}
+
+float sub_float(float x, float y) {
+  return x - y;
+}
+
+double sub_double(double x, double y) {
+  return x - y;
+}
+
+int32_t mul_i32(int32_t x, int32_t y) {
+  return x * y;
+}
+
+int64_t mul_i64(int64_t x, int64_t y) {
+  return x * y;
+}
+
+float mul_float(float x, float y) {
+  return x * y;
+}
+
+double mul_double(double x, double y) {
+  return x * y;
+}
+
+int32_t div_i32(int32_t x, int32_t y) {
+  return x / y;
+}
+
+int64_t div_i64(int64_t x, int64_t y) {
+  return x / y;
+}
+
+float div_float(float x, float y) {
+  return x / y;
+}
+
+double div_double(double x, double y) {
+  return x / y;
+}
+
 typedef struct {
   uint8_t tag;
   struct {} payload;

--- a/test_griff.sh
+++ b/test_griff.sh
@@ -4,6 +4,7 @@ TESTDIR=/tmp/griff_test
 mkdir $TESTDIR
 mkdir $TESTDIR/libs
 
+cabal exec griffc -- --via-binding ./runtime/griff/Builtin.grf -o $TESTDIR/Builtin.ll || exit 255
 cabal exec griffc -- --via-binding ./runtime/griff/Prelude.grf -o $TESTDIR/Prelude.ll || exit 255
 
 echo '=== no opt no lambdalift ==='
@@ -13,7 +14,7 @@ for file in `ls ./examples/griff | grep '\.grf$'`; do
   OUTFILE=$TESTDIR/${file/.grf/.out}
   cat ./examples/griff/$file | grep -q '^-- Expected: ' || exit 255
   cabal exec griffc -- --no-opt --no-lambdalift ./examples/griff/$file -o $LLFILE || exit 255
-  clang $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $LLFILE -o $OUTFILE || exit 255
+  clang $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $TESTDIR/Builtin.ll $LLFILE -o $OUTFILE || exit 255
   $OUTFILE || exit 255
   test "$($OUTFILE)" = "$(cat ./examples/griff/$file | grep '^-- Expected: ' | sed -e 's/^-- Expected: //')" || exit 255
   echo ""
@@ -26,7 +27,7 @@ for file in `ls ./examples/griff | grep '\.grf$'`; do
   OUTFILE=$TESTDIR/${file/.grf/.out}
   cat ./examples/griff/$file | grep -q '^-- Expected: ' || exit 255
   cabal exec griffc -- --no-opt ./examples/griff/$file -o $LLFILE || exit 255
-  clang $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $LLFILE -o $OUTFILE || exit 255
+  clang $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $TESTDIR/Builtin.ll $LLFILE -o $OUTFILE || exit 255
   $OUTFILE || exit 255
   test "$($OUTFILE)" = "$(cat ./examples/griff/$file | grep '^-- Expected: ' | sed -e 's/^-- Expected: //')" || exit 255
   echo ""
@@ -39,7 +40,7 @@ for file in `ls ./examples/griff | grep '\.grf$'`; do
   OUTFILE=$TESTDIR/${file/.grf/.out}
   cat ./examples/griff/$file | grep -q '^-- Expected: ' || exit 255
   cabal exec griffc -- --no-lambdalift ./examples/griff/$file -o $LLFILE || exit 255
-  clang $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $LLFILE -o $OUTFILE || exit 255
+  clang $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $TESTDIR/Builtin.ll $LLFILE -o $OUTFILE || exit 255
   $OUTFILE || exit 255
   test "$($OUTFILE)" = "$(cat ./examples/griff/$file | grep '^-- Expected: ' | sed -e 's/^-- Expected: //')" || exit 255
   echo ""
@@ -52,7 +53,7 @@ for file in `ls ./examples/griff | grep '\.grf$'`; do
   OUTFILE=$TESTDIR/${file/.grf/.out}
   cat ./examples/griff/$file | grep -q '^-- Expected: ' || exit 255
   cabal exec griffc -- ./examples/griff/$file -o $LLFILE || exit 255
-  clang -O2 $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $LLFILE -o $OUTFILE || exit 255
+  clang -O2 $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $TESTDIR/Builtin.ll $LLFILE -o $OUTFILE || exit 255
   $OUTFILE || exit 255
   test "$($OUTFILE)" = "$(cat ./examples/griff/$file | grep '^-- Expected: ' | sed -e 's/^-- Expected: //')" || exit 255
   echo ""
@@ -65,7 +66,7 @@ for file in `ls ./examples/griff | grep '\.grf$'`; do
   OUTFILE=$TESTDIR/${file/.grf/.out}
   cat ./examples/griff/$file | grep -q '^-- Expected: ' || exit 255
   cabal exec griffc -- --via-binding ./examples/griff/$file -o $LLFILE || exit 255
-  clang -O2 $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $LLFILE -o $OUTFILE || exit 255
+  clang -O2 $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $TESTDIR/Builtin.ll $LLFILE -o $OUTFILE || exit 255
   $OUTFILE || exit 255
   test "$($OUTFILE)" = "$(cat ./examples/griff/$file | grep '^-- Expected: ' | sed -e 's/^-- Expected: //')" || exit 255
   echo ""

--- a/test_griff_stack.sh
+++ b/test_griff_stack.sh
@@ -4,6 +4,7 @@ TESTDIR=/tmp/griff_test
 mkdir $TESTDIR
 mkdir $TESTDIR/libs
 
+stack exec griffc -- --via-binding ./runtime/griff/Builtin.grf -o $TESTDIR/Builtin.ll || exit 255
 stack exec griffc -- --via-binding ./runtime/griff/Prelude.grf -o $TESTDIR/Prelude.ll || exit 255
 
 echo '=== no opt no lambdalift ==='
@@ -13,7 +14,7 @@ for file in `ls ./examples/griff | grep '\.grf$'`; do
   OUTFILE=$TESTDIR/${file/.grf/.out}
   cat ./examples/griff/$file | grep -q '^-- Expected: ' || exit 255
   stack exec griffc -- --no-opt --no-lambdalift ./examples/griff/$file -o $LLFILE || exit 255
-  clang $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $LLFILE -o $OUTFILE || exit 255
+  clang $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $TESTDIR/Builtin.ll $LLFILE -o $OUTFILE || exit 255
   $OUTFILE || exit 255
   test "$($OUTFILE)" = "$(cat ./examples/griff/$file | grep '^-- Expected: ' | sed -e 's/^-- Expected: //')" || exit 255
   echo ""
@@ -26,7 +27,7 @@ for file in `ls ./examples/griff | grep '\.grf$'`; do
   OUTFILE=$TESTDIR/${file/.grf/.out}
   cat ./examples/griff/$file | grep -q '^-- Expected: ' || exit 255
   stack exec griffc -- --no-opt ./examples/griff/$file -o $LLFILE || exit 255
-  clang $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $LLFILE -o $OUTFILE || exit 255
+  clang $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $TESTDIR/Builtin.ll $LLFILE -o $OUTFILE || exit 255
   $OUTFILE || exit 255
   test "$($OUTFILE)" = "$(cat ./examples/griff/$file | grep '^-- Expected: ' | sed -e 's/^-- Expected: //')" || exit 255
   echo ""
@@ -39,7 +40,7 @@ for file in `ls ./examples/griff | grep '\.grf$'`; do
   OUTFILE=$TESTDIR/${file/.grf/.out}
   cat ./examples/griff/$file | grep -q '^-- Expected: ' || exit 255
   stack exec griffc -- --no-lambdalift ./examples/griff/$file -o $LLFILE || exit 255
-  clang $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $LLFILE -o $OUTFILE || exit 255
+  clang $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $TESTDIR/Builtin.ll $LLFILE -o $OUTFILE || exit 255
   $OUTFILE || exit 255
   test "$($OUTFILE)" = "$(cat ./examples/griff/$file | grep '^-- Expected: ' | sed -e 's/^-- Expected: //')" || exit 255
   echo ""
@@ -52,7 +53,7 @@ for file in `ls ./examples/griff | grep '\.grf$'`; do
   OUTFILE=$TESTDIR/${file/.grf/.out}
   cat ./examples/griff/$file | grep -q '^-- Expected: ' || exit 255
   stack exec griffc -- ./examples/griff/$file -o $LLFILE || exit 255
-  clang -O2 $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $LLFILE -o $OUTFILE || exit 255
+  clang -O2 $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $TESTDIR/Builtin.ll $LLFILE -o $OUTFILE || exit 255
   $OUTFILE || exit 255
   test "$($OUTFILE)" = "$(cat ./examples/griff/$file | grep '^-- Expected: ' | sed -e 's/^-- Expected: //')" || exit 255
   echo ""
@@ -65,7 +66,7 @@ for file in `ls ./examples/griff | grep '\.grf$'`; do
   OUTFILE=$TESTDIR/${file/.grf/.out}
   cat ./examples/griff/$file | grep -q '^-- Expected: ' || exit 255
   stack exec griffc -- --via-binding ./examples/griff/$file -o $LLFILE || exit 255
-  clang -O2 $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $LLFILE -o $OUTFILE || exit 255
+  clang -O2 $(pkg-config bdw-gc --libs --cflags) ./runtime/griff/rts.c $TESTDIR/Prelude.ll $TESTDIR/Builtin.ll $LLFILE -o $OUTFILE || exit 255
   $OUTFILE || exit 255
   test "$($OUTFILE)" = "$(cat ./examples/griff/$file | grep '^-- Expected: ' | sed -e 's/^-- Expected: //')" || exit 255
   echo ""


### PR DESCRIPTION
Add runtime/griff/Builtin.grf and remove primitive function definitions from Language.Griff.(Rename, TypeCheck, Desugar)